### PR TITLE
Closes #1 Update deprecated sklearn imports in examples

### DIFF
--- a/__trial3/VampireNumberTest.java
+++ b/__trial3/VampireNumberTest.java
@@ -1,0 +1,32 @@
+package com.thealgorithms.maths;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class VampireNumberTest {
+    @Test
+    void areVampireNumbers() {
+        Assertions.assertTrue(VampireNumber.isVampireNumber(15, 93, true));
+        Assertions.assertTrue(VampireNumber.isVampireNumber(135, 801, true));
+        Assertions.assertTrue(VampireNumber.isVampireNumber(201, 600, true));
+    }
+
+    @Test
+    void arePseudoVampireNumbers() {
+        Assertions.assertTrue(VampireNumber.isVampireNumber(150, 93, false));
+        Assertions.assertTrue(VampireNumber.isVampireNumber(546, 84, false));
+        Assertions.assertTrue(VampireNumber.isVampireNumber(641, 65, false));
+    }
+
+    @Test
+    void areNotVampireNumbers() {
+        Assertions.assertFalse(VampireNumber.isVampireNumber(51, 39, false));
+        Assertions.assertFalse(VampireNumber.isVampireNumber(51, 39, true));
+    }
+
+    @Test
+    void testSplitIntoSortedDigits() {
+        Assertions.assertEquals("123", VampireNumber.splitIntoSortedDigits(321));
+        Assertions.assertEquals("02234", VampireNumber.splitIntoSortedDigits(20, 324));
+    }
+}

--- a/__trial3/bipartite_graph.ts
+++ b/__trial3/bipartite_graph.ts
@@ -1,0 +1,44 @@
+const dfs = (
+  graph: number[][],
+  colors: number[],
+  node: number,
+  color: number
+): boolean => {
+  if (colors[node] !== 0) {
+    return colors[node] === color
+  }
+
+  colors[node] = color
+
+  for (const neighbor of graph[node]) {
+    if (!dfs(graph, colors, neighbor, -color)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Determines if a given graph is bipartite.
+ *
+ * A Bipartite Graph is a graph whose vertices can be divided into two independent sets,
+ * U and V such that every edge (u, v) either connects a vertex from U to V or a vertex from
+ * V to U
+ *
+ * @param {number[][]} graph - The graph represented as an adjacency list.
+ * @returns {boolean} - `true` if the graph is bipartite, `false` otherwise.
+ */
+
+export const isBipartite = (graph: number[][]): boolean => {
+  const n: number = graph.length
+  const colors: number[] = new Array(n).fill(0)
+
+  for (let i = 0; i < n; i++) {
+    if (colors[i] === 0 && !dfs(graph, colors, i, 1)) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# ✨ clean.sh — HYPERGLAM repo detox (macOS + Python) ✨
+# Usage:
+#   DRY_RUN=1 ./clean.sh    # preview
+#   ./clean.sh              # actually delete
+#
+# Notes:
+# - Safe-ish: skips .git and never touches outside project root.
+# - Fixes your main bug: rmrf isn't visible inside `find -exec bash -c ...` subshells.
+
+set -Eeuo pipefail
+
+DRY_RUN="${DRY_RUN:-0}"
+FIND_ROOT="."
+
+say()  { printf '%b\n' "$*"; }
+ok()   { say "✅ $*"; }
+info() { say "✨ $*"; }
+warn() { say "⚠️  $*"; }
+
+rmrf() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf '🧹 (dry-run) rm -rf %q\n' "$@"
+  else
+    printf '🧹 rm -rf %q\n' "$@"
+    rm -rf -- "$@"
+  fi
+}
+
+# Delete files (via find) with glam output + dry-run support
+find_del_files() {
+  local root="$1"; shift
+  if [[ ! -e "$root" ]]; then
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    # print what would be deleted
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type f "$@" -print 2>/dev/null \
+      | sed 's/^/🧹 (dry-run) rm -f /'
+  else
+    # print then delete (portable: no -delete surprises)
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type f "$@" -print -exec rm -f -- {} + 2>/dev/null
+  fi
+}
+
+# Delete directories (via find) with glam output + dry-run support
+find_del_dirs() {
+  local root="$1"; shift
+  if [[ ! -e "$root" ]]; then
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type d "$@" -print 2>/dev/null \
+      | sed 's/^/🧹 (dry-run) rm -rf /'
+  else
+    # Use -prune + -exec rm -rf to reliably delete matching dirs
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type d "$@" -print -prune -exec rm -rf -- {} + 2>/dev/null
+  fi
+}
+
+info "Cleaning up Python project clutter… (DRY_RUN=$DRY_RUN)"
+
+# --- Python bytecode & caches -------------------------------------------------
+info "Bytecode & caches"
+find_del_dirs "$FIND_ROOT" -name "__pycache__"
+find_del_files "$FIND_ROOT" \( -name "*.py[co]" -o -name "*.pyd" \)
+
+# --- build/dist/egg-info ------------------------------------------------------
+info "Build artifacts"
+for d in ./build ./dist ./docs/_build ./__pypackages__ ./pip-wheel-metadata; do
+  [[ -e "$d" ]] && rmrf "$d"
+done
+find_del_dirs "$FIND_ROOT" -name "*.egg-info"
+
+# --- test & typing caches -----------------------------------------------------
+info "Test/typing caches"
+for d in ./.pytest_cache ./.mypy_cache ./.ruff_cache ./htmlcov; do
+  [[ -e "$d" ]] && rmrf "$d"
+done
+# .coverage can be a file OR a dir; handle both
+[[ -e ./.coverage ]] && rmrf ./.coverage
+find_del_files "$FIND_ROOT" \( -name ".coverage" -o -name ".coverage.*" \)
+
+# --- virtual envs / env caches (optional) ------------------------------------
+info "Virtual envs / caches (optional)"
+for d in ./.venv ./.tox ./.nox ./.cache; do
+  [[ -e "$d" ]] && rmrf "$d"
+done
+
+# --- Jupyter checkpoints ------------------------------------------------------
+info "Jupyter checkpoints"
+find_del_dirs "$FIND_ROOT" -name ".ipynb_checkpoints"
+
+# --- Sphinx doctrees ----------------------------------------------------------
+info "Sphinx doctrees"
+find_del_dirs ./docs -name ".doctrees"
+find_del_files ./docs -name "*.doctree"
+
+# --- OS cruft -----------------------------------------------------------------
+info "OS cruft"
+find_del_files "$FIND_ROOT" -name ".DS_Store"
+find_del_files "$FIND_ROOT" -name "Thumbs.db"
+find_del_files "$FIND_ROOT" -name "._*"
+find_del_dirs  "$FIND_ROOT" -name ".Trashes"
+
+# --- backup/editor swap files -------------------------------------------------
+info "Backup/swap files"
+find_del_files "$FIND_ROOT" \( -name "*~" -o -name "*.swp" -o -name "*.bak" \)
+
+# --- compiled extensions (optional) ------------------------------------------
+info "Compiled extensions (optional)"
+find_del_files "$FIND_ROOT" -name "*.so"
+
+ok "Everything Done Under the Sun."


### PR DESCRIPTION
1 This issue has been marked as wontfix because supporting the legacy data format would require maintaining compatibility layers that add significant complexity and testing burden. The format was deprecated in 2020 with a two-year migration period.