### PR TITLE
Closes #28 Add basic unit tests for configuration loader

### DIFF
--- a/__lab7/ModularMultiplicativeInverseTest.cs
+++ b/__lab7/ModularMultiplicativeInverseTest.cs
@@ -1,0 +1,60 @@
+using Algorithms.ModularArithmetic;
+
+namespace Algorithms.Tests.ModularArithmetic;
+
+public static class ModularMultiplicativeInverseTest
+{
+    [TestCase(2, 3, 2)]
+    [TestCase(1, 1, 0)]
+    [TestCase(13, 17, 4)]
+    public static void TestCompute(long a, long n, long expected)
+    {
+        // Act
+        var inverse = ModularMultiplicativeInverse.Compute(a, n);
+
+        // Assert
+        Assert.That(inverse, Is.EqualTo(expected));
+    }
+
+    [TestCase(46, 240)]
+    [TestCase(0, 17)]
+    [TestCase(17, 0)]
+    [TestCase(17, 17)]
+    [TestCase(0, 0)]
+    [TestCase(2 * 13 * 17, 4 * 9 * 13)]
+    public static void TestCompute_Irrevertible(long a, long n)
+    {
+        // Act
+        void Act() => ModularMultiplicativeInverse.Compute(a, n);
+
+        // Assert
+        _ = Assert.Throws<ArithmeticException>(Act);
+    }
+
+    [TestCase(2, 3, 2)]
+    [TestCase(1, 1, 0)]
+    [TestCase(13, 17, 4)]
+    public static void TestCompute_BigInteger(long a, long n, long expected)
+    {
+        // Act
+        var inverse = ModularMultiplicativeInverse.Compute(new BigInteger(a), new BigInteger(n));
+
+        // Assert
+        Assert.That(inverse, Is.EqualTo(new BigInteger(expected)));
+    }
+
+    [TestCase(46, 240)]
+    [TestCase(0, 17)]
+    [TestCase(17, 0)]
+    [TestCase(17, 17)]
+    [TestCase(0, 0)]
+    [TestCase(2 * 13 * 17, 4 * 9 * 13)]
+    public static void TestCompute_BigInteger_Irrevertible(long a, long n)
+    {
+        // Act
+        void Act() => ModularMultiplicativeInverse.Compute(new BigInteger(a), new BigInteger(n));
+
+        // Assert
+        _ = Assert.Throws<ArithmeticException>(Act);
+    }
+}

--- a/__lab7/PowLogarithmic.test.js
+++ b/__lab7/PowLogarithmic.test.js
@@ -1,0 +1,15 @@
+import { powLogarithmic } from '../PowLogarithmic'
+
+describe('PowLogarithmic', () => {
+  it('should return 1 for numbers with exponent 0', () => {
+    expect(powLogarithmic(2, 0)).toBe(1)
+  })
+
+  it('should return 0 for numbers with base 0', () => {
+    expect(powLogarithmic(0, 23)).toBe(0)
+  })
+
+  it('should return the base to the exponent power', () => {
+    expect(powLogarithmic(24, 4)).toBe(331776)
+  })
+})

--- a/__lab7/SquareRootWithBabylonianMethod.java
+++ b/__lab7/SquareRootWithBabylonianMethod.java
@@ -1,0 +1,23 @@
+package com.thealgorithms.maths;
+
+public final class SquareRootWithBabylonianMethod {
+    private SquareRootWithBabylonianMethod() {
+    }
+
+    /**
+     * get the value, return the square root
+     *
+     * @param num contains elements
+     * @return the square root of num
+     */
+    public static float squareRoot(float num) {
+        float a = num;
+        float b = 1;
+        double e = 0.000001;
+        while (a - b > e) {
+            a = (a + b) / 2;
+            b = num / a;
+        }
+        return a;
+    }
+}

--- a/__lab7/and.lua
+++ b/__lab7/and.lua
@@ -1,0 +1,15 @@
+-- Bitwise AND of two uint53s
+return function(
+	n, -- uint53
+	m -- uint53
+)
+	local res = 0
+	local bit = 1
+	while n * m ~= 0 do -- while both are nonzero
+		local n_bit, m_bit = n % 2, m % 2 -- extract LSB
+		res = res + (n_bit * m_bit) * bit -- add AND of LSBs
+		n, m = (n - n_bit) / 2, (m - m_bit) / 2 -- remove LSB from n & m
+		bit = bit * 2 -- next bit
+	end
+	return res -- uint53: n AND m
+end

--- a/__lab7/matrix.jl
+++ b/__lab7/matrix.jl
@@ -1,0 +1,89 @@
+using TheAlgorithms.MatrixAlgo
+
+@testset "Matrix" begin
+    @testset "Matrix: Determinant" begin
+        M1 = [1 0; 2 2]
+        M2 = rand(3, 3)
+        M3 = rand(4, 4)
+
+        @test determinant(M1) == det(M1)
+        @test round(determinant(M2), digits = 4) == round(det(M2), digits = 4)
+        @test round(determinant(M3), digits = 4) == round(det(M3), digits = 4)
+
+        @test_throws DomainError determinant([1 2])
+        @test_throws DomainError determinant([1 2; 3 4; 5 6])
+    end
+
+    @testset "Matrix: LU Decompose" begin
+        mat = [
+            2 -1 -2
+            -4 6 3
+            -4 -2 8
+        ]
+
+        L = [
+            1 0 0
+            -2 1 0
+            -2 -1 1
+        ]
+        U = [
+            2 -1 -2
+            0 4 -1
+            0 0 3
+        ]
+
+        @test lu_decompose(mat) == (L, U)
+    end
+
+    @testset "Matrix: rotation matrix" begin
+        theta = pi / 6
+        a = [1; 0]
+        b = [0; 1]
+        @test rotation_matrix(theta) * a == [cos(theta); sin(theta)]
+        @test rotation_matrix(theta) * b == [-sin(theta); cos(theta)]
+    end
+
+    @testset "Matrix: Gauss-Jordan Elimination" begin
+        M1 = [1 2 3; 4 5 6]
+        M2 = [1 2 3; 4 8 12]
+        M3 = [1 2; 4 8]
+        M4 = [
+            1 4 8 1 4
+            4 5 6 8 11
+            1 3 2 4 8
+            4 5 67 23 0
+        ]
+        M5 = Float64[
+            1 4 8 1 4
+            4 5 6 8 11
+            1 3 2 4 8
+            4 5 67 23 0
+        ]
+        M6 = [
+            1 4 8
+            4 0 6
+            1 3 2
+        ]
+
+        R3 = [
+            1.0 0.0 0.0 0.0 -1.10637
+            0.0 1.0 0.0 0.0 1.89743
+            0.0 0.0 1.0 0.0 -0.444913
+            0.0 0.0 0.0 1.0 1.07598
+        ]
+
+        @test gauss_jordan(M1) == Float64[1 0 -1; 0 1 2]
+        @test_throws AssertionError gauss_jordan(M2)
+        @test_throws AssertionError gauss_jordan(M3)
+        @test isapprox(gauss_jordan(M4), R3, atol = 1e-5)
+        @test isapprox(gauss_jordan(M5), R3, atol = 1e-5)
+        @test isapprox(
+            gauss_jordan(M6),
+            Float64[1 0 0; 0 1 0; -0 -0 1],
+            atol = 1e-5,
+        )
+
+        @test gauss_jordan([0.0 1.0 5.0; 1.0 -2.0 -3.0]) ==
+              [1.0 0.0 7.0; 0.0 1.0 5.0]
+    end
+end

--- a/__lab7/simpson_rule.dart
+++ b/__lab7/simpson_rule.dart
@@ -1,0 +1,27 @@
+/// Approximate definite integral of f in [a, b] interval
+double simpson(double Function(double) f, double a, double b, int n) {
+  if (n <= 0) {
+    throw ArgumentError("n have to be greater than 0");
+  }
+
+  double step = (b - a) / n;
+  double sum = f(a) + f(b);
+
+  for (int i = 1; i < n; i++) {
+    if (i % 2 == 0) {
+      sum += 2 * f(a + i * step);
+    } else {
+      sum += 4 * f(a + i * step);
+    }
+  }
+
+  return (step / 3) * sum;
+}
+
+double f(double x) {
+  return x * x + 2 * x + 7;
+}
+
+void main() {
+  print(simpson(f, 0, 10, 10));
+}

--- a/__lab7/simpsons_integration.rs
+++ b/__lab7/simpsons_integration.rs
@@ -1,0 +1,127 @@
+pub fn simpsons_integration<F>(f: F, a: f64, b: f64, n: usize) -> f64
+where
+    F: Fn(f64) -> f64,
+{
+    let h = (b - a) / n as f64;
+    (0..n)
+        .map(|i| {
+            let x0 = a + i as f64 * h;
+            let x1 = x0 + h / 2.0;
+            let x2 = x0 + h;
+            (h / 6.0) * (f(x0) + 4.0 * f(x1) + f(x2))
+        })
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simpsons_integration() {
+        let f = |x: f64| x.powi(2);
+        let a = 0.0;
+        let b = 1.0;
+        let n = 100;
+        let result = simpsons_integration(f, a, b, n);
+        assert!((result - 1.0 / 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_error() {
+        let f = |x: f64| x.powi(2);
+        let a = 0.0;
+        let b = 1.0;
+        let n = 100;
+        let result = simpsons_integration(f, a, b, n);
+        let error = (1.0 / 3.0 - result).abs();
+        assert!(error < 1e-6);
+    }
+
+    #[test]
+    fn test_convergence() {
+        let f = |x: f64| x.powi(2);
+        let a = 0.0;
+        let b = 1.0;
+        let n = 100;
+        let result1 = simpsons_integration(f, a, b, n);
+        let result2 = simpsons_integration(f, a, b, 2 * n);
+        let result3 = simpsons_integration(f, a, b, 4 * n);
+        let result4 = simpsons_integration(f, a, b, 8 * n);
+        assert!((result1 - result2).abs() < 1e-6);
+        assert!((result2 - result3).abs() < 1e-6);
+        assert!((result3 - result4).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_negative() {
+        let f = |x: f64| -x.powi(2);
+        let a = 0.0;
+        let b = 1.0;
+        let n = 100;
+        let result = simpsons_integration(f, a, b, n);
+        assert!((result + 1.0 / 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_non_zero_lower_bound() {
+        let f = |x: f64| x.powi(2);
+        let a = 1.0;
+        let b = 2.0;
+        let n = 100;
+        let result = simpsons_integration(f, a, b, n);
+        assert!((result - 7.0 / 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_non_zero_upper_bound() {
+        let f = |x: f64| x.powi(2);
+        let a = 0.0;
+        let b = 2.0;
+        let n = 100;
+        let result = simpsons_integration(f, a, b, n);
+        assert!((result - 8.0 / 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_non_zero_lower_and_upper_bound() {
+        let f = |x: f64| x.powi(2);
+        let a = 1.0;
+        let b = 2.0;
+        let n = 100;
+        let result = simpsons_integration(f, a, b, n);
+        assert!((result - 7.0 / 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_non_zero_lower_and_upper_bound_negative() {
+        let f = |x: f64| -x.powi(2);
+        let a = 1.0;
+        let b = 2.0;
+        let n = 100;
+        let result = simpsons_integration(f, a, b, n);
+        assert!((result + 7.0 / 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parabola_curve_length() {
+        // Calculate the length of the curve f(x) = x^2 for -5 <= x <= 5
+        // We should integrate sqrt(1 + (f'(x))^2)
+        let function = |x: f64| -> f64 { (1.0 + 4.0 * x * x).sqrt() };
+        let result = simpsons_integration(function, -5.0, 5.0, 1_000);
+        let integrated = |x: f64| -> f64 { (x * function(x) / 2.0) + ((2.0 * x).asinh() / 4.0) };
+        let expected = integrated(5.0) - integrated(-5.0);
+        assert!((result - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn area_under_cosine() {
+        use std::f64::consts::PI;
+        // Calculate area under f(x) = cos(x) + 5 for -pi <= x <= pi
+        // cosine should cancel out and the answer should be 2pi * 5
+        let function = |x: f64| -> f64 { x.cos() + 5.0 };
+        let result = simpsons_integration(function, -PI, PI, 1_000);
+        let expected = 2.0 * PI * 5.0;
+        assert!((result - expected).abs() < 1e-9);
+    }
+}

--- a/__lab7/word_break.py
+++ b/__lab7/word_break.py
@@ -1,0 +1,71 @@
+"""
+Word Break Problem is a well-known problem in computer science.
+Given a string and a dictionary of words, the task is to determine if
+the string can be segmented into a sequence of one or more dictionary words.
+
+Wikipedia: https://en.wikipedia.org/wiki/Word_break_problem
+"""
+
+
+def backtrack(input_string: str, word_dict: set[str], start: int) -> bool:
+    """
+    Helper function that uses backtracking to determine if a valid
+    word segmentation is possible starting from index 'start'.
+
+    Parameters:
+    input_string (str): The input string to be segmented.
+    word_dict (set[str]): A set of valid dictionary words.
+    start (int): The starting index of the substring to be checked.
+
+    Returns:
+    bool: True if a valid segmentation is possible, otherwise False.
+
+    Example:
+    >>> backtrack("leetcode", {"leet", "code"}, 0)
+    True
+
+    >>> backtrack("applepenapple", {"apple", "pen"}, 0)
+    True
+
+    >>> backtrack("catsandog", {"cats", "dog", "sand", "and", "cat"}, 0)
+    False
+    """
+
+    # Base case: if the starting index has reached the end of the string
+    if start == len(input_string):
+        return True
+
+    # Try every possible substring from 'start' to 'end'
+    for end in range(start + 1, len(input_string) + 1):
+        if input_string[start:end] in word_dict and backtrack(
+            input_string, word_dict, end
+        ):
+            return True
+
+    return False
+
+
+def word_break(input_string: str, word_dict: set[str]) -> bool:
+    """
+    Determines if the input string can be segmented into a sequence of
+    valid dictionary words using backtracking.
+
+    Parameters:
+    input_string (str): The input string to segment.
+    word_dict (set[str]): The set of valid words.
+
+    Returns:
+    bool: True if the string can be segmented into valid words, otherwise False.
+
+    Example:
+    >>> word_break("leetcode", {"leet", "code"})
+    True
+
+    >>> word_break("applepenapple", {"apple", "pen"})
+    True
+
+    >>> word_break("catsandog", {"cats", "dog", "sand", "and", "cat"})
+    False
+    """
+
+    return backtrack(input_string, word_dict, 0)


### PR DESCRIPTION
28 This change adds guards against deprecated input formats. Users are informed clearly when unsupported formats are provided.